### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,4 @@
 [book]
-multilingual = false
 src = "src"
 title = "The OpenRA Book"
 authors = [ "Taryn Hill <taryn@phrohdoh.com>", "abcdefg30 <alphabet@streber24.de>" ]


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10